### PR TITLE
Add "max_len" for autoregressive.

### DIFF
--- a/examples/preprocess/download_split_ml100k.py
+++ b/examples/preprocess/download_split_ml100k.py
@@ -248,9 +248,7 @@ def parse_cmd_arguments():
 
     return parsed_results
 
-def prepare_ml100k(arguments):
-    output_name = arguments['output_name']
-    need_max_len = arguments['need_max_len']
+def prepare_ml100k(output_name='ml-100k',need_max_len=0):
     # Download MovieLens-100k
     url = "https://files.grouplens.org/datasets/movielens/ml-100k.zip"
     folder_path = os.path.expanduser("~/.unirec/dataset")
@@ -393,4 +391,6 @@ def prepare_ml100k(arguments):
 if __name__ == "__main__":
     arguments = parse_cmd_arguments()
     print(arguments)
-    prepare_ml100k(arguments)
+    output_name = arguments.get('output_name', 'ml-100k')
+    need_max_len = arguments.get('need_max_len', 0)
+    prepare_ml100k(output_name,need_max_len)

--- a/examples/preprocess/download_split_ml100k.py
+++ b/examples/preprocess/download_split_ml100k.py
@@ -5,6 +5,7 @@ import os
 import json
 import requests
 import zipfile
+import argparse
 from tqdm import tqdm
 import pandas as pd
 import numpy as np
@@ -230,8 +231,26 @@ def merge_category(data, min_item_in_cate=50):
 
     return cate2idx, item2cate, num_cates
 
+def parse_cmd_arguments():
+    parser = argparse.ArgumentParser() 
+     
+    parser.add_argument("--output_name", type=str, default="ml-100k") 
+    parser.add_argument("--need_max_len", type=int, default=0)
 
-def prepare_ml100k():
+    (args, unknown) = parser.parse_known_args()  
+    # print(args)
+    parsed_results = {}
+    for arg in sorted(vars(args)):
+        value = getattr(args, arg)
+        if value is not None and value not in ['none', 'None']:
+            parsed_results[arg] = value
+    
+
+    return parsed_results
+
+def prepare_ml100k(arguments):
+    output_name = arguments['output_name']
+    need_max_len = arguments['need_max_len']
     # Download MovieLens-100k
     url = "https://files.grouplens.org/datasets/movielens/ml-100k.zip"
     folder_path = os.path.expanduser("~/.unirec/dataset")
@@ -250,7 +269,7 @@ def prepare_ml100k():
     item_info_path = os.path.join(extract_path, "ml-100k", "u.item")
     # _path = os.path.dirname(__file__)
     # dataset_folder = os.path.abspath(os.path.join(_path, "../../data/"))
-    outpath = os.path.join(folder_path, "ml-100k")
+    outpath = os.path.join(folder_path, output_name)
     if not os.path.exists(outpath):
         os.makedirs(outpath)
 
@@ -307,6 +326,12 @@ def prepare_ml100k():
     full_user_history['item_seq'] = full_user_history[item_col_name].apply(lambda x: ",".join(map(str,x)))
     full_user_history = full_user_history[[user_col_name, 'item_seq']]
     full_user_history.to_csv(os.path.join(outpath, 'full_user_history.csv'), index=False, sep='\t')
+    
+    # max_len is the maximum length of the sequence corresponding to the target interaction.
+    # For example, sequence corresponding to (u, i, max_len) is history_u[:max_len], 
+    # where history_u is the interaction history of user u and i is the target item. 
+    if need_max_len:
+        data['max_len'] = data.groupby(user_col_name).cumcount()
 
     df_train0, df_test = split_train_test_set(data, col_name=user_col_name, col_names_2_return=None, seed=seed)
     df_train, df_valid = split_train_test_set(df_train0, col_name=user_col_name, col_names_2_return=None, seed=seed)
@@ -315,10 +340,15 @@ def prepare_ml100k():
     user_history = df_train0.groupby(by=user_col_name, as_index=False).agg(list).reset_index(drop=True)
     user_history['item_seq'] = user_history[item_col_name].apply(lambda x: ",".join(map(str,x)))
     user_history = user_history[[user_col_name, 'item_seq']]
+  
+    columns_to_keep = [user_col_name, item_col_name]  
+    if need_max_len:  
+        columns_to_keep.append('max_len')
 
-    df_train = df_train[[user_col_name, item_col_name]]
-    df_valid = df_valid[[user_col_name, item_col_name]]
-    df_test = df_test[[user_col_name, item_col_name]]
+    df_train = df_train[columns_to_keep]  
+    df_test = df_test[columns_to_keep]  
+    df_valid = df_valid[columns_to_keep]
+
     df_train.to_csv(os.path.join(outpath, 'train.csv'), index=False, sep='\t')
     df_valid.to_csv(os.path.join(outpath, 'valid.csv'), index=False, sep='\t')
     df_test.to_csv(os.path.join(outpath, 'test.csv'), index=False, sep='\t')
@@ -361,4 +391,6 @@ def prepare_ml100k():
     return True
 
 if __name__ == "__main__":
-    prepare_ml100k()
+    arguments = parse_cmd_arguments()
+    print(arguments)
+    prepare_ml100k(arguments)

--- a/examples/preprocess/split-run_prepare_data-ml-100k-sequential-max_len.sh
+++ b/examples/preprocess/split-run_prepare_data-ml-100k-sequential-max_len.sh
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+###############################################################################################
+### Please modify the following variables according to your device and mission requirements ###
+###############################################################################################
+ROOT_DIR="$HOME/workspace/UniRec" # path to UniRec
+###############################################################################################
+
+
+# default parameters for local run
+RAW_DATA_DIR="$HOME/.unirec/dataset/"
+
+MY_DIR=$ROOT_DIR
+DATA_ROOT="$ROOT_DIR/data"
+OUTPUT_ROOT="$ROOT_DIR/output"
+
+dataset_name='ml-100k-max_len'
+
+
+export PYTHONPATH=$MY_DIR
+
+raw_datapath="$RAW_DATA_DIR/$dataset_name" 
+dataset_outpathroot=$DATA_ROOT
+example_yaml_file="$MY_DIR/unirec/config/dataset/example.yaml"
+
+DATA_TYPE='SeqRecDataset'
+
+cd $MY_DIR"/examples/preprocess"
+echo $PWD
+python download_split_ml100k.py \
+    --output_name=$dataset_name \
+    --need_max_len=1 \
+
+python prepare_data.py \
+    --raw_datapath=$raw_datapath \
+    --outpathroot=$dataset_outpathroot \
+    --dataset_name=$dataset_name \
+    --example_yaml_file=$example_yaml_file \
+    --data_type=$DATA_TYPE \
+    --index_by_zero=0 \
+    --sep="\t"  \
+    --train_file='train.csv'\
+    --train_file_format='user-item-max_len' \
+    --train_file_has_header=1 \
+    --train_file_col_names="['user_id', 'item_id', 'max_len']" \
+    --train_neg_k=0 \
+    --valid_file='valid.csv'\
+    --valid_file_format='user-item-max_len' \
+    --valid_file_has_header=1 \
+    --valid_file_col_names="['user_id', 'item_id', 'max_len']" \
+    --valid_neg_k=0 \
+    --test_file='test.csv'\
+    --test_file_format='user-item-max_len' \
+    --test_file_has_header=1 \
+    --test_file_col_names="['user_id', 'item_id', 'max_len']" \
+    --test_neg_k=0 \
+    --user_history_file='user_history.csv'\
+    --user_history_file_format='user-item_seq' \
+    --user_history_file_has_header=1 \
+    --user_history_file_col_names="['user_id', 'item_seq']" \

--- a/examples/training/train_seq_model_ml100k_max_len.sh
+++ b/examples/training/train_seq_model_ml100k_max_len.sh
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+#!/bin/bash 
+
+###############################################################################################
+### Please modify the following variables according to your device and mission requirements ###
+###############################################################################################
+LOCAL_ROOT="$HOME/workspace/UniRec"  # path to UniRec
+###############################################################################################
+
+
+# default parameters for local run
+MY_DIR=$LOCAL_ROOT
+ALL_DATA_ROOT="$LOCAL_ROOT/data"
+OUTPUT_ROOT="$LOCAL_ROOT/output" 
+MODEL_NAME='SASRec' # [ MF, AvgHist, AttHist, SVDPlusPlus, GRU, SASRec, ConvFormer, FASTConvFormer]
+loss_type='bce' # [bce, bpr, softmax]
+DATASET_NAME="ml-100k-max_len"
+max_seq_len=10
+verbose=2
+
+cd $MY_DIR
+export PYTHONPATH=$PWD 
+
+# overall config
+DATA_TYPE='SeqRecDataset'  # BaseDataset SeqRecDataset
+
+# train
+learning_rate=0.001
+test_protocol='one_vs_all'  # 'one_vs_k' 'one_vs_all' 'session_aware'
+
+
+exp_name="$MODEL_NAME-$DATASET_NAME"
+
+ALL_RESULTS_ROOT="$OUTPUT_ROOT/$DATASET_NAME/$MODEL_NAME"
+mkdir -p $ALL_RESULTS_ROOT
+### train ###################################
+
+python unirec/main/main.py \
+    --config_dir="unirec/config" \
+    --model=$MODEL_NAME \
+    --dataloader=$DATA_TYPE \
+    --dataset=$DATASET_NAME \
+    --dataset_path=$ALL_DATA_ROOT"/"$DATASET_NAME \
+    --output_path=$ALL_RESULTS_ROOT"/train" \
+    --learning_rate=$learning_rate \
+    --dropout_prob=0.0 \
+    --embedding_size=64 \
+    --hidden_size=64 \
+    --use_pre_item_emb=0 \
+    --loss_type=$loss_type \
+    --max_seq_len=$max_seq_len \
+    --has_user_bias=0 \
+    --has_item_bias=0 \
+    --epochs=100  \
+    --early_stop=10 \
+    --batch_size=512 \
+    --n_sample_neg_train=5 \
+    --neg_by_pop_alpha=1.0 \
+    --valid_protocol=$test_protocol \
+    --test_protocol=$test_protocol \
+    --grad_clip_value=-1 \
+    --weight_decay=1e-6 \
+    --history_mask_mode='autoregressive' \
+    --user_history_filename="user_history" \
+    --user_history_file_format="user-item_seq" \
+    --metrics="['hit@10;20', 'ndcg@10;20']" \
+    --key_metric="ndcg@10" \
+    --num_workers=4 \
+    --num_workers_test=0 \
+    --verbose=$verbose \
+    --exp_name=$exp_name \
+    --use_wandb=0
+# done

--- a/tests/test_dataset/test_preprocess.py
+++ b/tests/test_dataset/test_preprocess.py
@@ -291,25 +291,25 @@ def test_preprocess_maxlen_data():
     config['test_file_format'] = 'user-item-max_len'
     config['test_file_col_names'] = "['user_id', 'item_id', 'max_len']"
     process_transaction_dataset(config)
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name)), "processed data folder not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], CONFIG['dataset_name'], 'test.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
-    if os.path.exists(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv')):
-        shutil.copyfile(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv'),
-                        os.path.join(CONFIG['outpathroot'], ds_name, 'item_meta_morec.csv'))
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name)), "processed data folder not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'train.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'train.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
+    if os.path.exists(os.path.join(config['raw_datapath'], 'item_meta_morec.csv')):
+        shutil.copyfile(os.path.join(config['raw_datapath'], 'item_meta_morec.csv'),
+                        os.path.join(config['outpathroot'], ds_name, 'item_meta_morec.csv'))
 
-def test_preprocess_maxlen_data():
+def test_preprocess_seq_data():
     ds_name = 'ml-100k-seq'
     prepare_ml100k(output_name=ds_name,need_max_len=1)
     config = copy.deepcopy(CONFIG)
@@ -317,23 +317,23 @@ def test_preprocess_maxlen_data():
     config['dataset_name'] = ds_name
     config['data_type'] = 'SeqRecDataset'
     process_transaction_dataset(config)
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name)), "processed data folder not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], CONFIG['dataset_name'], 'test.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
-    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.ftr')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.pkl')) or \
-        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
-    if os.path.exists(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv')):
-        shutil.copyfile(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv'),
-                        os.path.join(CONFIG['outpathroot'], ds_name, 'item_meta_morec.csv'))
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name)), "processed data folder not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'train.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'train.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
+    assert os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.ftr')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.pkl')) or \
+        os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
+    if os.path.exists(os.path.join(config['raw_datapath'], 'item_meta_morec.csv')):
+        shutil.copyfile(os.path.join(config['raw_datapath'], 'item_meta_morec.csv'),
+                        os.path.join(config['outpathroot'], ds_name, 'item_meta_morec.csv'))
 
 if __name__ == "__main__":
     pytest.main(["test_preprocess.py", "-s"])

--- a/tests/test_dataset/test_preprocess.py
+++ b/tests/test_dataset/test_preprocess.py
@@ -278,6 +278,62 @@ def test_preprocess_adaranker_data():
         os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.pkl')) or \
         os.path.exists(os.path.join(config['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
 
+def test_preprocess_maxlen_data():
+    ds_name = 'ml-100k-max_len'
+    prepare_ml100k(output_name=ds_name,need_max_len=1)
+    config = copy.deepcopy(CONFIG)
+    config['raw_datapath'] = os.path.expanduser("~/.unirec/dataset/ml-100k-max_len")
+    config['dataset_name'] = ds_name
+    config['train_file_format'] = 'user-item-max_len'
+    config['train_file_col_names'] = "['user_id', 'item_id', 'max_len']"
+    config['valid_file_format'] = 'user-item-max_len'
+    config['valid_file_col_names'] = "['user_id', 'item_id', 'max_len']"
+    config['test_file_format'] = 'user-item-max_len'
+    config['test_file_col_names'] = "['user_id', 'item_id', 'max_len']"
+    process_transaction_dataset(config)
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name)), "processed data folder not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], CONFIG['dataset_name'], 'test.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
+    if os.path.exists(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv')):
+        shutil.copyfile(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv'),
+                        os.path.join(CONFIG['outpathroot'], ds_name, 'item_meta_morec.csv'))
+
+def test_preprocess_maxlen_data():
+    ds_name = 'ml-100k-seq'
+    prepare_ml100k(output_name=ds_name,need_max_len=1)
+    config = copy.deepcopy(CONFIG)
+    config['raw_datapath'] = os.path.expanduser("~/.unirec/dataset/ml-100k-seq")
+    config['dataset_name'] = ds_name
+    config['data_type'] = 'SeqRecDataset'
+    process_transaction_dataset(config)
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name)), "processed data folder not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'data.info')), "data.info file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'train.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'],ds_name, 'train.tsv')), "train file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'valid.tsv')), "valid file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], CONFIG['dataset_name'], 'test.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'test.tsv')), "test file not created sucessfully"
+    assert os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.ftr')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.pkl')) or \
+        os.path.exists(os.path.join(CONFIG['outpathroot'], ds_name, 'user_history.tsv')), "user_history file not created sucessfully"
+    if os.path.exists(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv')):
+        shutil.copyfile(os.path.join(CONFIG['raw_datapath'], 'item_meta_morec.csv'),
+                        os.path.join(CONFIG['outpathroot'], ds_name, 'item_meta_morec.csv'))
 
 if __name__ == "__main__":
-    pytest.main(["test_morec.py", "-s"])
+    pytest.main(["test_preprocess.py", "-s"])

--- a/tests/test_dataset/test_preprocess.py
+++ b/tests/test_dataset/test_preprocess.py
@@ -311,7 +311,7 @@ def test_preprocess_maxlen_data():
 
 def test_preprocess_seq_data():
     ds_name = 'ml-100k-seq'
-    prepare_ml100k(output_name=ds_name,need_max_len=1)
+    prepare_ml100k(output_name=ds_name,need_max_len=0)
     config = copy.deepcopy(CONFIG)
     config['raw_datapath'] = os.path.expanduser("~/.unirec/dataset/ml-100k-seq")
     config['dataset_name'] = ds_name

--- a/unirec/config/dataset/ml-100k-max_len.yaml
+++ b/unirec/config/dataset/ml-100k-max_len.yaml
@@ -1,0 +1,10 @@
+group_size: -1
+n_items: 1017
+n_neg_test_from_sampling: 0
+n_neg_train_from_sampling: 0
+n_neg_valid_from_sampling: 0
+n_users: 940
+test_file_format: user-item-max_len
+train_file_format: user-item-max_len
+user_history_file_format: user-item_seq
+valid_file_format: user-item-max_len

--- a/unirec/config/dataset/ml-100k-seq.yaml
+++ b/unirec/config/dataset/ml-100k-seq.yaml
@@ -3,7 +3,7 @@ n_items: 1017
 n_neg_test_from_sampling: 0
 n_neg_train_from_sampling: 0
 n_neg_valid_from_sampling: 0
-n_users: 1017
+n_users: 940
 test_file_format: user-item
 train_file_format: user-item
 user_history_file_format: user-item_seq

--- a/unirec/config/dataset/ml-100k-seq.yaml
+++ b/unirec/config/dataset/ml-100k-seq.yaml
@@ -1,0 +1,10 @@
+group_size: -1
+n_items: 1017
+n_neg_test_from_sampling: 0
+n_neg_train_from_sampling: 0
+n_neg_valid_from_sampling: 0
+n_users: 1017
+test_file_format: user-item
+train_file_format: user-item
+user_history_file_format: user-item_seq
+valid_file_format: user-item

--- a/unirec/constants/protocols.py
+++ b/unirec/constants/protocols.py
@@ -63,6 +63,7 @@ class ColNames(Enum):
     USER_AND_HISTORY = 'user_id_item_seq'
     INDEX_GROUP = 'index_list'
     VALUE_GROUP = 'value_list'
+    MAX_LEN = 'max_len'
 
 class DatasetType(Enum):
     BaseDataset = 'BaseDataset'

--- a/unirec/constants/protocols.py
+++ b/unirec/constants/protocols.py
@@ -13,6 +13,12 @@ class DataFileFormat(Enum):
     # user_id, item_id.  This is the interaction format.
     T1 = 'user-item' 
 
+    # user_id, item_id, max_len. 
+    # max_len is the maximum length of the sequence corresponding to the target interaction.
+    # For example, sequence corresponding to (u, i, max_len) is history_u[:max_len], 
+    # where history_u is the interaction history of user u and i is the target item.
+    T1_1 = 'user-item-max_len'
+
     # user_id, item_id, label
     T2 = 'user-item-label' 
 

--- a/unirec/data/dataset/aerecdataset.py
+++ b/unirec/data/dataset/aerecdataset.py
@@ -34,7 +34,7 @@ class AERecDataset(SeqRecDataset):
                 _n_rows1 = len(raw_data_pd)
                 self.logger.info('{0} / {1} rows remains.'.format(_n_rows1, _n_rows0))
             
-            if data_format in {DataFileFormat.T1.value, DataFileFormat.T2.value, DataFileFormat.T2_1.value, DataFileFormat.T3.value}:
+            if data_format in {DataFileFormat.T1.value, DataFileFormat.T1_1.value, DataFileFormat.T2.value, DataFileFormat.T2_1.value, DataFileFormat.T3.value}:
                 self.logger.info('Group interactions by user_id.')
                 _n_rows0 = len(raw_data_pd)
                 raw_data_pd = raw_data_pd.groupby(ColNames.USERID.value)[ColNames.ITEMID.value].apply(lambda x:np.array(x)).to_frame().reset_index()

--- a/unirec/data/dataset/basedataset.py
+++ b/unirec/data/dataset/basedataset.py
@@ -102,6 +102,8 @@ class BaseDataset(Dataset):
         _type = self.config['data_format']
         if _type == DataFileFormat.T1.value:
             t = ['user_id', 'item_id',]
+        elif _type == DataFileFormat.T1_1.value:
+            t = ['user_id', 'item_id', 'max_len']
         elif _type == DataFileFormat.T2.value:
             t = ['user_id', 'item_id', 'label']
         elif _type == DataFileFormat.T2_1.value:
@@ -154,6 +156,9 @@ class BaseDataset(Dataset):
     def __getitem__(self, index):
         _type = self.config['data_format']
         sample = self.dataset[index] 
+
+        if _type == DataFileFormat.T1_1.value:
+            max_len = sample[2]
         
         if self.transform is not None:
             sample = self.transform(sample)
@@ -187,6 +192,8 @@ class BaseDataset(Dataset):
         if _type == DataFileFormat.T2_1.value:
             session_id = sample[3]
             return_tup = return_tup + (session_id,)
+        elif _type == DataFileFormat.T1_1.value:
+            return_tup = return_tup + (max_len, )
         
         if self.use_features and item_id is not None:
             item_features = self.item2features[item_id] # np.ndarray and int are both supported

--- a/unirec/data/dataset/basedataset.py
+++ b/unirec/data/dataset/basedataset.py
@@ -87,7 +87,9 @@ class BaseDataset(Dataset):
             } 
 
         ## additional columns for some dataformat:
-        if _type == DataFileFormat.T2_1.value:
+        if _type == DataFileFormat.T1_1.value:
+            self.return_key_2_index['max_len'] = len(self.return_key_2_index)
+        elif _type == DataFileFormat.T2_1.value:
             self.return_key_2_index['session_id'] = len(self.return_key_2_index)
         if self.use_features:
             self.return_key_2_index['item_features'] = len(self.return_key_2_index)

--- a/unirec/data/dataset/basedataset.py
+++ b/unirec/data/dataset/basedataset.py
@@ -189,11 +189,11 @@ class BaseDataset(Dataset):
         
         return_tup = (user_id, item_id, label) if user_id is not None else (index_list, value_list, label)
 
-        if _type == DataFileFormat.T2_1.value:
+        if _type == DataFileFormat.T1_1.value:
+            return_tup = return_tup + (max_len, )
+        elif _type == DataFileFormat.T2_1.value:
             session_id = sample[3]
             return_tup = return_tup + (session_id,)
-        elif _type == DataFileFormat.T1_1.value:
-            return_tup = return_tup + (max_len, )
         
         if self.use_features and item_id is not None:
             item_features = self.item2features[item_id] # np.ndarray and int are both supported

--- a/unirec/data/dataset/seqrecdataset.py
+++ b/unirec/data/dataset/seqrecdataset.py
@@ -45,12 +45,7 @@ class SeqRecDataset(BaseDataset):
             item_seq, item_seq_len, time_seq = self.add_seq_transform((elements[0], elements[1]))
         item_seq = self._padding(item_seq)
         item_seq_len = min(item_seq_len, self.config['max_seq_len'])  
-
-        if _type == DataFileFormat.T1_1.value:
-            # delete max_len as it will not be used next.
-            elements = elements[:3] + elements[4:] 
-        elements = elements + (item_seq, item_seq_len)
-        
+      
         elements = elements + (item_seq, item_seq_len)
         if self.use_features:
             item_seq_features = self.item2features[item_seq]

--- a/unirec/data/dataset/seqrecdataset.py
+++ b/unirec/data/dataset/seqrecdataset.py
@@ -35,11 +35,21 @@ class SeqRecDataset(BaseDataset):
     def add_user_history_transform(self, transform):
         self.add_seq_transform = transform
 
-    def __getitem__(self, index):        
+    def __getitem__(self, index):
+        _type = self.config['data_format']        
         elements = super(SeqRecDataset, self).__getitem__(index)   # user_id, item_id, label, ...
-        item_seq, item_seq_len, time_seq = self.add_seq_transform((elements[0], elements[1]))
+        if _type == DataFileFormat.T1_1.value:
+            # elements is (user_id, item_id, label, max_len, ...)
+            item_seq, item_seq_len, time_seq = self.add_seq_transform((elements[0], elements[1], elements[3]))  
+        else:
+            item_seq, item_seq_len, time_seq = self.add_seq_transform((elements[0], elements[1]))
         item_seq = self._padding(item_seq)
-        item_seq_len = min(item_seq_len, self.config['max_seq_len']) 
+        item_seq_len = min(item_seq_len, self.config['max_seq_len'])  
+
+        if _type == DataFileFormat.T1_1.value:
+            # delete max_len as it will not be used next.
+            elements = elements[:3] + elements[4:] 
+        elements = elements + (item_seq, item_seq_len)
         
         elements = elements + (item_seq, item_seq_len)
         if self.use_features:

--- a/unirec/data/transform/adduserhistory.py
+++ b/unirec/data/transform/adduserhistory.py
@@ -13,12 +13,13 @@ class AddUserHistory(object):
         mask_mode: If the item history is a sequence, we suggest to use autoregressive to avoid use future inforamtion.
                     Otherwise use unorder.
     '''
-    def __init__(self, user2history, mask_mode='unorder', user2history_time=None, seq_last=0): 
+    def __init__(self, user2history, mask_mode='unorder', user2history_time=None, seq_last=0, data_type=None): 
         self.user2history = user2history
         self.user2history_time = user2history_time
         self.empty_history = np.zeros((1,), dtype=np.int32)
         self.mask_mode = mask_mode
         self.seq_last = seq_last
+        self.data_type = data_type
 
     def get_fake_label(self, k):
         if hasattr(self, 'fake_label'):
@@ -53,15 +54,21 @@ class AddUserHistory(object):
                         history_time[idx] = 0
         elif self.mask_mode == HistoryMaskMode.Autoregressive.value:
             n = []
-            for idx, item in enumerate(history):
-                if item in items:
-                    n.append(idx)
-            if len(n) == 0:
-                pass
-            else:
-                n = n[-1] if self.seq_last else random.choice(n)
+            # For format T1_1, sample is: [userid, itemid, label, max_len, ...]
+            if self.data_type == DataFileFormat.T1_1.value:
+                n = sample[2]
                 history = history[:n]
                 history_time = history_time[:n] if self.user2history_time is not None else None
+            else:
+                for idx, item in enumerate(history):
+                    if item in items:
+                        n.append(idx)
+                if len(n) == 0:
+                    pass
+                else:
+                    n = n[-1] if self.seq_last else random.choice(n)
+                    history = history[:n]
+                    history_time = history_time[:n] if self.user2history_time is not None else None
         
         return history, len(history), history_time
         

--- a/unirec/data/transform/adduserhistory.py
+++ b/unirec/data/transform/adduserhistory.py
@@ -13,13 +13,13 @@ class AddUserHistory(object):
         mask_mode: If the item history is a sequence, we suggest to use autoregressive to avoid use future inforamtion.
                     Otherwise use unorder.
     '''
-    def __init__(self, user2history, mask_mode='unorder', user2history_time=None, seq_last=0, data_type=None): 
+    def __init__(self, user2history, mask_mode='unorder', user2history_time=None, seq_last=0, data_format=None): 
         self.user2history = user2history
         self.user2history_time = user2history_time
         self.empty_history = np.zeros((1,), dtype=np.int32)
         self.mask_mode = mask_mode
         self.seq_last = seq_last
-        self.data_type = data_type
+        self.data_format = data_format
 
     def get_fake_label(self, k):
         if hasattr(self, 'fake_label'):
@@ -55,7 +55,7 @@ class AddUserHistory(object):
         elif self.mask_mode == HistoryMaskMode.Autoregressive.value:
             n = []
             # For format T1_1, sample is: [userid, itemid, label, max_len, ...]
-            if self.data_type == DataFileFormat.T1_1.value:
+            if self.data_format in [DataFileFormat.T1_1.value]:
                 n = sample[2]
                 history = history[:n]
                 history_time = history_time[:n] if self.user2history_time is not None else None

--- a/unirec/model/base/ranker.py
+++ b/unirec/model/base/ranker.py
@@ -17,7 +17,7 @@ class Ranker(AbstractRecommender):
     def forward_scores(self, item_id=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None):
         raise NotImplementedError
 
-    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True):
+    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True, max_len=None):
         scores = self.forward_scores(item_id, item_features, item_seq, item_seq_len,  item_seq_features)
         if self.SCORE_CLIP > 0:
             scores = torch.clamp(scores, min=-1.0*self.SCORE_CLIP, max=self.SCORE_CLIP) 

--- a/unirec/model/base/recommender.py
+++ b/unirec/model/base/recommender.py
@@ -43,7 +43,7 @@ class BaseRecommender(AbstractRecommender):
         user_e = self.user_embedding(user_id)
         return user_e
     
-    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True):
+    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True, max_len=None):
         if self.loss_type == LossFuncType.FULLSOFTMAX.value and self.training:
             label = item_id
             in_item_id = torch.arange(self.n_items).to(self.device)

--- a/unirec/model/cf/multivae.py
+++ b/unirec/model/cf/multivae.py
@@ -92,7 +92,7 @@ class MultiVAE(BaseRecommender):
         
         return scores
 
-    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True):
+    def forward(self, user_id=None, item_id=None, label=None, item_features=None, item_seq=None, item_seq_len=None, item_seq_features=None, time_seq=None, session_id=None, reduction=True, return_loss_only=True, max_len=None):
         # items_emb = self.item_embedding.weight
         in_item_id = torch.arange(self.n_items).to(self.device)
         in_item_features = torch.tensor(self.item2features, dtype=torch.int32).to(self.device) if self.use_features else None


### PR DESCRIPTION
This PR introduces a new data format to specify maximum sequence lengths for user interactions and updates the processing of sequential datasets by dropping the first interaction.

Checklist:

 - [x] Added "user-item-max_len" data format
 - [x] Dropped the first interaction in sequential datasets
 - [x] Included `split-run_prepare_data-ml-100k-sequential-max_len.sh` and `train_seq_model_ml100k_max_len.sh`  for data preparation and model training validation
 - [x] Added test cases 
 - [x] Passed all test cases